### PR TITLE
chore: making routerPush async

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -74,13 +74,13 @@ export const router = createRouter({
   ],
 })
 
-export function routerPush (name: AppRouteNames, params?: RouteParams): ReturnType<typeof router.push> {
+export async function routerPush (name: AppRouteNames, params?: RouteParams): ReturnType<typeof router.push> {
   if (params !== undefined) {
-    return router.push({
+    return await router.push({
       name,
       params,
     })
   } else {
-    return router.push({ name })
+    return await router.push({ name })
   }
 }


### PR DESCRIPTION
The repo use such code snippet below:
```
await routerPush('global-feed')
```
so I think making the function to `async` make sense.