### PR TITLE
fix: putProfile payload missing user key

### DIFF
--- a/src/services/profile/putProfile.ts
+++ b/src/services/profile/putProfile.ts
@@ -9,5 +9,5 @@ export interface PutProfileForm {
 }
 
 export function putProfile (form: PutProfileForm): Promise<User> {
-  return request.put<UserResponse>('/user', form).then(res => res.user)
+  return request.put<UserResponse>('/user', { user: form }).then(res => res.user)
 }


### PR DESCRIPTION
Currently updating the profile throws a 500 error:

![image](https://user-images.githubusercontent.com/20022818/155841407-05d248ab-42a6-49c8-9ea4-40806d70be16.png)

According to the API Swagger, [PUT /user](https://api.realworld.io/api-docs/#/User%20and%20Authentication/UpdateCurrentUser) payload expects a top-level `user` key which was missing in `putProfile` request handler.