### PR TITLE
fix: lint script not working on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "serve": "vite preview",
     "lint:script": "eslint \"{src/**/*.{ts,vue},cypress/**/*.js}\"",
     "lint:tsc": "vue-tsc --noEmit",
-    "lint": "concurrently 'yarn build' 'yarn lint:tsc' 'yarn lint:script'",
+    "lint": "concurrently \"yarn build\" \"yarn lint:tsc\" \"yarn lint:script\"",
     "test:unit": "jest",
     "test:e2e": "yarn build && concurrently -rk -s first \"yarn serve\" \"cypress run -c baseUrl=http://localhost:5000\"",
     "test:e2e:ci": "cypress run -C cypress.prod.json",


### PR DESCRIPTION
lint script doesn't work in Windows due to single quotes:

![image](https://user-images.githubusercontent.com/20022818/155841743-1ffa6612-f291-4df2-ab5f-f396f10ea67c.png)

Changing them to `\"` fixes the problem.