### PR TITLE
Minor code improvements

### DIFF
--- a/src/components/AppLink.vue
+++ b/src/components/AppLink.vue
@@ -2,7 +2,6 @@
   <router-link
     :aria-label="props.name"
     :to="props"
-    v-bind="attrs"
   >
     <slot />
   </router-link>
@@ -10,7 +9,6 @@
 
 <script setup lang="ts">
 import type { AppRouteNames } from 'src/router'
-import { useAttrs } from 'vue'
 import type { RouteParams } from 'vue-router'
 import { RouterLink } from 'vue-router'
 
@@ -22,6 +20,4 @@ interface Props {
 const props = withDefaults(defineProps<Props>(), {
   params: () => ({}),
 })
-
-const attrs = useAttrs()
 </script>

--- a/src/components/ArticleDetail.vue
+++ b/src/components/ArticleDetail.vue
@@ -51,7 +51,7 @@ import ArticleDetailMeta from './ArticleDetailMeta.vue'
 
 const route = useRoute()
 const slug = route.params.slug as string
-const article = reactive<Article>(await getArticle(slug))
+const article: Article = reactive(await getArticle(slug))
 
 const articleHandledBody = computed(() => marked(article.body))
 

--- a/src/composable/useArticles.ts
+++ b/src/composable/useArticles.ts
@@ -24,17 +24,13 @@ export function useArticles () {
 
     if (articlesType.value === 'my-feed') {
       responsePromise = getFeeds(page.value)
-    }
-    if (articlesType.value === 'tag-feed' && tag.value !== undefined) {
+    } else if (articlesType.value === 'tag-feed' && tag.value) {
       responsePromise = getArticlesByTag(tag.value, page.value)
-    }
-    if (articlesType.value === 'user-feed' && username.value !== undefined) {
+    } else if (articlesType.value === 'user-feed' && username.value) {
       responsePromise = getProfileArticles(username.value, page.value)
-    }
-    if (articlesType.value === 'user-favorites-feed' && username.value !== undefined) {
+    } else if (articlesType.value === 'user-favorites-feed' && username.value) {
       responsePromise = getFavoritedArticles(username.value, page.value)
-    }
-    if (articlesType.value === 'global-feed') {
+    } else if (articlesType.value === 'global-feed') {
       responsePromise = getArticles(page.value)
     }
 

--- a/src/composable/useArticles.ts
+++ b/src/composable/useArticles.ts
@@ -12,7 +12,7 @@ import { useRoute } from 'vue-router'
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/explicit-function-return-type
 export function useArticles () {
-  const { articlesType, tag, username, metaChanged } = getArticlesMeta()
+  const { articlesType, tag, username, metaChanged } = useArticlesMeta()
 
   const articles = ref<Article[]>([])
   const articlesCount = ref(0)
@@ -87,13 +87,13 @@ const routeNameToArticlesType: Partial<Record<AppRouteNames, ArticlesType>> = ({
   'profile-favorites': 'user-favorites-feed',
 })
 
-interface GetArticlesMetaReturn {
+interface UseArticlesMetaReturn {
   tag: ComputedRef<string>
   username: ComputedRef<string>
   articlesType: ComputedRef<ArticlesType>
   metaChanged: ComputedRef<string>
 }
-function getArticlesMeta (): GetArticlesMetaReturn {
+function useArticlesMeta (): UseArticlesMetaReturn {
   const route = useRoute()
 
   const tag = ref('')

--- a/src/pages/Article.vue
+++ b/src/pages/Article.vue
@@ -1,9 +1,7 @@
 <template>
   <div class="article-page">
     <Suspense>
-      <template #default>
-        <ArticleDetail />
-      </template>
+      <ArticleDetail />
       <template #fallback>
         <div class="container page">
           Article is downloading...
@@ -12,13 +10,11 @@
     </Suspense>
 
     <Suspense>
-      <template #default>
-        <div class="row">
-          <div class="col-xs-12 col-md-8 offset-md-2">
-            <ArticleDetailComments />
-          </div>
+      <div class="row">
+        <div class="col-xs-12 col-md-8 offset-md-2">
+          <ArticleDetailComments />
         </div>
-      </template>
+      </div>
       <template #fallback>
         <div class="container page">
           Comments are downloading...

--- a/src/pages/EditArticle.vue
+++ b/src/pages/EditArticle.vue
@@ -82,7 +82,7 @@ const route = useRoute()
 const router = useRouter()
 const slug = computed<string>(() => route.params.slug as string)
 
-const form = reactive<FormState>({
+const form: FormState = reactive({
   title: '',
   description: '',
   body: '',

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -13,13 +13,11 @@
       <div class="row">
         <div class="col-md-9">
           <Suspense>
-            <template #default>
-              <ArticlesList
-                use-global-feed
-                use-my-feed
-                use-tag-feed
-              />
-            </template>
+            <ArticlesList
+              use-global-feed
+              use-my-feed
+              use-tag-feed
+            />
             <template #fallback>
               Articles are downloading...
             </template>
@@ -29,9 +27,7 @@
         <div class="col-md-3">
           <div class="sidebar">
             <Suspense>
-              <template #default>
-                <PopularTags />
-              </template>
+              <PopularTags />
               <template #fallback>
                 Popular tags are downloading...
               </template>

--- a/src/pages/Login.vue
+++ b/src/pages/Login.vue
@@ -67,7 +67,7 @@ import { updateUser } from 'src/store/user'
 import { reactive, ref } from 'vue'
 
 const formRef = ref<HTMLFormElement | null>(null)
-const form = reactive<PostLoginForm>({
+const form: PostLoginForm = reactive({
   email: '',
   password: '',
 })

--- a/src/pages/Profile.vue
+++ b/src/pages/Profile.vue
@@ -50,12 +50,10 @@
       <div class="row">
         <div class="col-xs-12 col-md-10 offset-md-1">
           <Suspense>
-            <template #default>
-              <ArticlesList
-                use-user-feed
-                use-user-favorited
-              />
-            </template>
+            <ArticlesList
+              use-user-feed
+              use-user-favorited
+            />
             <template #fallback>
               Articles are downloading...
             </template>

--- a/src/pages/Register.vue
+++ b/src/pages/Register.vue
@@ -74,7 +74,7 @@ import { updateUser } from 'src/store/user'
 import { reactive, ref } from 'vue'
 
 const formRef = ref<HTMLFormElement | null>(null)
-const form = reactive<PostRegisterForm>({
+const form: PostRegisterForm = reactive({
   username: '',
   email: '',
   password: '',

--- a/src/pages/Settings.vue
+++ b/src/pages/Settings.vue
@@ -79,7 +79,7 @@ import { putProfile, PutProfileForm } from 'src/services/profile/putProfile'
 import { checkAuthorization, updateUser, user } from 'src/store/user'
 import { computed, onMounted, reactive } from 'vue'
 
-const form = reactive<PutProfileForm>({})
+const form: PutProfileForm = reactive({})
 
 const onSubmit = async () => {
   const filteredForm = Object.entries(form).reduce((a, [k, v]) => (v === null ? a : { ...a, [k]: v }), {})


### PR DESCRIPTION
This PR address some of the issues listed in #92:

- [x] No need to write `<template #default>` for suspense
- [x] `useArticles` composable:
  - In `fetchArticles` function, since `articleType` can only have one value, it's better to use `if-else` rather than only `if` to skip other checks.
  - `getArticlesMeta` function is acting like a composable. So maybe it's better to rename it to `useArticlesMeta`
- [x] [Vue docs](https://vuejs.org/guide/typescript/composition-api.html#typing-reactive) doesn't recommend using generic argument for `reactive()`. So it may be better to change current generic usage.
- [x] In `AppLink` component, useAttrs and `v-bind="attrs"` can be removed because of [Fallthrough Attributes](https://vuejs.org/guide/components/attrs.html#fallthrough-attributes)