### PR TITLE
Fix validations

### DIFF
--- a/cypress/integration/auth.test.js
+++ b/cypress/integration/auth.test.js
@@ -46,6 +46,14 @@ describe('Auth', () => {
         cy.wrap($el.checkValidity()).should('to.be', false)
       })
     })
+
+    it('should not allow visiting login page when the user is logged in', () => {
+      cy.login()
+
+      cy.visit('/#/login')
+
+      cy.url().should('match', /\/#\/$/)
+    })
   })
 
   describe('Register', () => {
@@ -80,6 +88,14 @@ describe('Auth', () => {
       cy.wait('@registerRequest')
       cy.contains('email has already been taken')
       cy.contains('username has already been taken')
+    })
+
+    it('should not allow visiting register page when the user is logged in', () => {
+      cy.login()
+
+      cy.visit('/#/register')
+
+      cy.url().should('match', /\/#\/$/)
     })
   })
 })

--- a/src/pages/Login.vue
+++ b/src/pages/Login.vue
@@ -75,6 +75,8 @@ const form = reactive<PostLoginForm>({
 const errors = ref<PostLoginErrors>({})
 
 const login = async () => {
+  errors.value = {}
+
   if (!formRef.value?.checkValidity()) return
 
   const result = await postLogin(form)

--- a/src/pages/Register.vue
+++ b/src/pages/Register.vue
@@ -83,6 +83,8 @@ const form = reactive<PostRegisterForm>({
 const errors = ref<PostRegisterErrors>({})
 
 const register = async () => {
+  errors.value = {}
+
   if (!formRef.value?.checkValidity()) return
 
   const result = await postRegister(form)

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,5 +1,6 @@
 import { createRouter, createWebHashHistory, RouteParams } from 'vue-router'
 import Home from './pages/Home.vue'
+import { isAuthorized } from './store/user'
 
 export type AppRouteNames = 'global-feed'
 | 'my-feed'
@@ -50,11 +51,13 @@ export const router = createRouter({
       name: 'login',
       path: '/login',
       component: () => import('./pages/Login.vue'),
+      beforeEnter: () => !isAuthorized.value,
     },
     {
       name: 'register',
       path: '/register',
       component: () => import('./pages/Register.vue'),
+      beforeEnter: () => !isAuthorized.value,
     },
     {
       name: 'profile',

--- a/src/utils/map-checkable-response.ts
+++ b/src/utils/map-checkable-response.ts
@@ -15,7 +15,7 @@ export const mapAuthorizationResponse = <T>(result: Either<NetworkError, T>): Ei
 export const mapValidationResponse = <E, T>(result: Either<NetworkError, T>): Either<ValidationError<E>, T> => {
   if (result.isOk()) {
     return success(result.value)
-  } else if (result.value.response.status === 422) {
+  } else if ([422, 403].includes(result.value.response.status)) {
     return fail(new ValidationError<E>(result.value.response))
   } else {
     throw result.value


### PR DESCRIPTION
This PR address some issues listed in #92:
1. Login and register page route guards (Currently we can move to the login page by typing the address in the URL bar even when we are already logged in)

2. `mapValidationResponse` does not handle 403 error

![403](https://user-images.githubusercontent.com/20022818/155950477-0e8a9e16-f56f-4255-a061-d12ae64d5db6.PNG)

- This behavior is not documented in the [Swagger](https://api.realworld.io/api-docs/#/User%20and%20Authentication/Login) but checking the [official API code](https://github.com/gothinkster/node-express-prisma-v1-official-app/blob/6ac99ea5aeadc4e001dd4d6933c2e269f878a969/src/services/auth.service.ts#L121) confirms that. (Maybe a PR should be made on that repo and update the docs too)

3. Reset errors when re-submitting the forms