### PR TITLE
Fix: remove horizontal overflow on article page

### DIFF
--- a/src/pages/Article.vue
+++ b/src/pages/Article.vue
@@ -28,3 +28,9 @@
 import ArticleDetail from 'src/components/ArticleDetail.vue'
 import ArticleDetailComments from 'src/components/ArticleDetailComments.vue'
 </script>
+
+<style scoped>
+.row{
+  margin-right: 0;
+}
+</style>


### PR DESCRIPTION
Removed the horizontal overflow on the article page.

![horizontal overflow](https://user-images.githubusercontent.com/53666196/176799720-5e70a20b-4675-4dcb-ae59-ef929338514a.png)
.