### PR TITLE
Switching Authorization scheme from Bearer to Token

### DIFF
--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -6,7 +6,7 @@ export const limit = 10
 
 export const api = new Api({
   baseUrl: `${CONFIG.API_HOST}/api`,
-  securityWorker: token => token ? { headers: { Authorization: `Bearer ${String(token)}` } } : {},
+  securityWorker: token => token ? { headers: { Authorization: `Token ${String(token)}` } } : {},
   baseApiParams: {
     headers: {
       'content-type': ContentType.Json,


### PR DESCRIPTION
The [RealWorld OpenAPI spec](https://github.com/gothinkster/realworld/blob/77b112cb97cf996706afc607d269f76328624a53/api/openapi.yml#L801) specifies the `Token` and not `Bearer` scheme, so the current implementation is incompatible with most backends
This PR provides a potential fix

Thanks in advance