### PR TITLE
fix: add route guards redirect and 404 not-found page

### DIFF
--- a/src/pages/NotFound.spec.ts
+++ b/src/pages/NotFound.spec.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+import { render } from '@testing-library/vue'
+import { renderOptions } from 'src/utils/test/test.utils'
+import NotFound from './NotFound.vue'
+
+describe('# NotFound page', () => {
+  it('should render not found message', () => {
+    const { getByText } = render(NotFound, renderOptions())
+
+    expect(getByText('Page Not Found')).toBeTruthy()
+    expect(getByText('Go to Home')).toBeTruthy()
+  })
+})

--- a/src/pages/NotFound.vue
+++ b/src/pages/NotFound.vue
@@ -1,0 +1,16 @@
+<template>
+  <div class="container page">
+    <div class="row">
+      <div class="col-md-8 offset-md-2">
+        <h1>Page Not Found</h1>
+        <p>The page you're looking for doesn't exist.</p>
+        <AppLink
+          class="btn btn-primary"
+          name="global-feed"
+        >
+          Go to Home
+        </AppLink>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/router.spec.ts
+++ b/src/router.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { userStorage } from 'src/store/user'
+import fixtures from 'src/utils/test/fixtures'
+import { createTestRouter } from 'src/utils/test/test.utils'
+
+describe('# Router guards', () => {
+  it('should redirect to home when logged-in user navigates to /login', async () => {
+    userStorage.set(fixtures.user)
+    const router = createTestRouter()
+    await router.push('/login')
+    await router.isReady()
+
+    expect(router.currentRoute.value.name).toBe('global-feed')
+
+    userStorage.remove()
+  })
+
+  it('should redirect to home when logged-in user navigates to /register', async () => {
+    userStorage.set(fixtures.user)
+    const router = createTestRouter()
+    await router.push('/register')
+    await router.isReady()
+
+    expect(router.currentRoute.value.name).toBe('global-feed')
+
+    userStorage.remove()
+  })
+
+  it('should allow unauthenticated user to access /login', async () => {
+    userStorage.remove()
+    const router = createTestRouter()
+    await router.push('/login')
+    await router.isReady()
+
+    expect(router.currentRoute.value.name).toBe('login')
+  })
+
+  it('should match not-found route for unknown paths', async () => {
+    const router = createTestRouter()
+    await router.push('/some-nonexistent-path')
+    await router.isReady()
+
+    expect(router.currentRoute.value.name).toBe('not-found')
+  })
+})

--- a/src/router.ts
+++ b/src/router.ts
@@ -14,6 +14,7 @@ export type AppRouteNames
     | 'profile'
     | 'profile-favorites'
     | 'settings'
+    | 'not-found'
 
 export const routes: RouteRecordRaw[] = [
   {
@@ -50,13 +51,13 @@ export const routes: RouteRecordRaw[] = [
     name: 'login',
     path: '/login',
     component: () => import('./pages/Login.vue'),
-    beforeEnter: () => !isAuthorized(),
+    beforeEnter: () => isAuthorized() ? { name: 'global-feed' as const } : true,
   },
   {
     name: 'register',
     path: '/register',
     component: () => import('./pages/Register.vue'),
-    beforeEnter: () => !isAuthorized(),
+    beforeEnter: () => isAuthorized() ? { name: 'global-feed' as const } : true,
   },
   {
     name: 'profile',
@@ -72,6 +73,11 @@ export const routes: RouteRecordRaw[] = [
     name: 'settings',
     path: '/settings',
     component: () => import('./pages/Settings.vue'),
+  },
+  {
+    name: 'not-found',
+    path: '/:pathMatch(.*)*',
+    component: () => import('./pages/NotFound.vue'),
   },
 ]
 export const router = createRouter({


### PR DESCRIPTION
## Summary
- Logged-in users navigating to `/login` or `/register` are now redirected to the home page instead of silently cancelling navigation
- Added a catch-all route with a NotFound page for unmatched paths
- Added unit tests for route guards and NotFound page

Closes #92

## Test plan
- [x] Route guard tests: logged-in user redirected from /login and /register
- [x] Route guard tests: unauthenticated user can access /login
- [x] NotFound page renders correctly
- [x] Unknown paths match the not-found route
- [x] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)